### PR TITLE
Add filters to customize output in category and product pages

### DIFF
--- a/woocommerce-afterpay.php
+++ b/woocommerce-afterpay.php
@@ -1168,7 +1168,7 @@ function woocommerce_afterpay_init() {
 
 			$amount = wc_price($price/4);
 			$text = str_replace(array('[AMOUNT]'),$amount,$settings['product-pages-info-text']);
-			echo '<p class="afterpay-payment-info">'.$text.'</p>';
+			echo apply_filters( 'woocommerce_afterpay_product_pages_info_text', '<p class="afterpay-payment-info">'.$text.'</p>', $post->ID );
 		}
 	}
 
@@ -1201,7 +1201,7 @@ function woocommerce_afterpay_init() {
 
 			$amount = wc_price($price/4);
 			$text = str_replace(array('[AMOUNT]'),$amount,$settings['category-pages-info-text']);
-			echo '<p class="afterpay-payment-info">'.$text.'</p>';
+			echo apply_filters( 'woocommerce_afterpay_category_pages_info_text', '<p class="afterpay-payment-info">'.$text.'</p>', $post->ID );
 		}
 
 	}

--- a/woocommerce-afterpay.php
+++ b/woocommerce-afterpay.php
@@ -1179,7 +1179,7 @@ function woocommerce_afterpay_init() {
 			 * @param string $text
 			 * @param int $product_id
 			 */
-			echo apply_filters( 'woocommerce_afterpay_product_pages_info_text', '<p class="afterpay-payment-info">'.$text.'</p>', $post->ID );
+			echo apply_filters( 'afterpay_product_pages_info_text', '<p class="afterpay-payment-info">'.$text.'</p>', $post->ID );
 		}
 	}
 
@@ -1223,7 +1223,7 @@ function woocommerce_afterpay_init() {
 			 * @param string $text
 			 * @param int $product_id
 			 */
-			echo apply_filters( 'woocommerce_afterpay_category_pages_info_text', '<p class="afterpay-payment-info">'.$text.'</p>', $post->ID );
+			echo apply_filters( 'afterpay_category_pages_info_text', '<p class="afterpay-payment-info">'.$text.'</p>', $post->ID );
 		}
 
 	}

--- a/woocommerce-afterpay.php
+++ b/woocommerce-afterpay.php
@@ -1168,6 +1168,17 @@ function woocommerce_afterpay_init() {
 
 			$amount = wc_price($price/4);
 			$text = str_replace(array('[AMOUNT]'),$amount,$settings['product-pages-info-text']);
+
+			/**
+			 * woocommerce_afterpay_product_pages_info_text
+			 *
+			 * Filters the AfterPay message shown in product pages.
+			 *
+			 * @since 1.3.1
+			 *
+			 * @param string $text
+			 * @param int $product_id
+			 */
 			echo apply_filters( 'woocommerce_afterpay_product_pages_info_text', '<p class="afterpay-payment-info">'.$text.'</p>', $post->ID );
 		}
 	}
@@ -1201,6 +1212,17 @@ function woocommerce_afterpay_init() {
 
 			$amount = wc_price($price/4);
 			$text = str_replace(array('[AMOUNT]'),$amount,$settings['category-pages-info-text']);
+			
+			/**
+			 * woocommerce_afterpay_category_pages_info_text
+			 *
+			 * Filters the AfterPay message shown in product pages.
+			 *
+			 * @since 1.3.1
+			 *
+			 * @param string $text
+			 * @param int $product_id
+			 */
 			echo apply_filters( 'woocommerce_afterpay_category_pages_info_text', '<p class="afterpay-payment-info">'.$text.'</p>', $post->ID );
 		}
 


### PR DESCRIPTION
The current setup allows setting two unique messages to be shown, per product, in product and category pages. 

This pull request allows further customization of the shown message through two filters, allowing (for example) hiding the message for products in a given category, or below a price.