### PR TITLE
Fix function filter payment_callback

### DIFF
--- a/woocommerce-afterpay.php
+++ b/woocommerce-afterpay.php
@@ -648,6 +648,11 @@ function woocommerce_afterpay_init() {
 				$order = new WC_Order( $order_id );
 			}
 
+			// Only do things if the order exists and has been paid through AfterPay
+			if ( ! $order || $order->get_payment_method() !== 'afterpay' ) {
+				return $order_id;
+			}
+			
 			// Avoid emptying the cart if it's cancelled
 			if (isset($body->status) && $body->status == "CANCELLED") {
 				return $order_id;


### PR DESCRIPTION
Changes to make function filter payment_callback, associated to filter hook woocommerce_thankyou_order_id, not to do anything if the corresponding order is not found or if the order wasn't paid through AfterPay.